### PR TITLE
Adding options to customize layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,7 +136,10 @@ app.initialize = function (done) {
         if (app.isProduction &&
             !req.path.startsWith('/swagger-ui') &&
             req.get('x-forwarded-proto') != 'https')
-            return next(new Error('You are running in "production" (NODE_ENV) mode, but not on https. This is not supported.'));
+            if (portalGlobals.glob.network.forceRedirectToHttps === true)
+                return res.redirect(301, 'https://' + req.headers.host + req.url);
+            else
+                return next(new Error('You are running in "production" (NODE_ENV) mode, but not on https. This is not supported.'));
         next();
     });
 

--- a/views/apis.jade
+++ b/views/apis.jade
@@ -4,7 +4,8 @@ mixin apiDef(anApi)
     .col-md-4
         .panel.panel-default
             .panel-body.wicked-api-body
-                img(src='/images/api-icon.png')
+                if glob.views.apis.showApiIcon
+                    img(src='/images/api-icon.png')
                 if anApi.auth == 'oauth2'
                     a(href='/help/apis' target='_blank')
                         img(src='/images/oauth2-icon-32.png' align='right' title='API is secured over OAuth 2.0')
@@ -23,13 +24,13 @@ block content
     .jumbotron.wicked-api-title
         .container.wicked-title-container
             h1= title
-            
-            p This is the index of APIs which are available for this API Portal.
-        
+
+            p= glob.views.apis.titleTagline
+
     .container.wicked-container
         if desc
             p!= desc
-            
+
         p &nbsp;
 
         - var length = apilist.length

--- a/views/applications.jade
+++ b/views/applications.jade
@@ -4,28 +4,26 @@ block content
     .jumbotron.wicked-application-title
         .container.wicked-title-container
             h1 Your Applications
-            
-            p.
-                 This page displays all your registered applications. It also allows you to register
-                 a new application.
-    
+
+            p= glob.views.applications.titleTagline
+
     .container.wicked-container
-        
+
         p.
             An application is the entity to which you attach your API subscriptions. You can own or co-own
             applications with other developers.
-            
+
         if !authUser
             .panel.panel-danger
                 .panel-heading
                     h4.panel-title Not logged in
                 .panel-body
                     p You are not logged in. Applications can only be created if you are logged in.
-            
+
                     a(href="/login?redirect=/applications").btn.btn-default Log in &raquo;
                     | &nbsp;&nbsp;
                     a(href="/signup").btn.btn-default Sign up &raquo;
-            
+
         else
             .panel-group
                 div(class='panel panel-default')
@@ -59,9 +57,9 @@ block content
 
                                 p
                                     button(type='submit').btn.btn-success Register Application
-            
+
             hr
-            
+
             if applications.length == 0
                 br
                 h4 You don't have any registered applications

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -20,7 +20,7 @@ html
     link(rel='stylesheet', href='/content/wicked.css')
     link(rel="stylesheet", href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css")
     script(src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js")
-    
+
     block scripts
   body
     if authUser && authUser.id == '1'
@@ -36,20 +36,20 @@ html
                         portal for the first time. You must only use this user to give your actual user admin rights
                         to the portal; after that, delete the password for the superuser (with the ID '1'), so that
                         it is no longer possible to log in as this user.
-                    
+
                     p Your Todos right now are:
-                    
+
                     ul
                         li
                             a(href='/admin/users') Go to the Admin/Users page, find your own user, and assign an 'admin' group to it
                         li
                             a(href='/users/1') Open this User's user profile, and delete the password from it
-                    
+
                     p.
                         If you don't have a user in your own name yet, please create that user first, either by signing
                         up using email address or password, or by using one of the federated logins you have configured (if applicable).
-                    
-        
+
+
     nav(class="navbar navbar-default navbar-fixed-top")
         .container
             .navbar-header
@@ -58,12 +58,12 @@ html
                     span.icon-bar
                     span.icon-bar
                     span.icon-bar
-                a.pull-left(href='http://wicked.haufe.io' target='_blank')
+                a.pull-left(href='/')
                     img(src='/content/images/wicked-40.png' style='margin-top: 5px; margin-right: 5px;' title='wicked project home')
 
             div(id="navbar", class="collapse navbar-collapse")
                 ul(class="nav navbar-nav")
-                    if (route == '/') 
+                    if (route == '/')
                         li.active
                             a(href="/") Home
                     else
@@ -72,9 +72,10 @@ html
                     if route == '/apis'
                         li.active
                             a(href="/apis") APIs
-                    else
+                    else if glob.layout.linkMenuVisibleToGuest || authUser
                         li
                             a(href="/apis") APIs
+
                     if route == '/applications'
                         li.active
                             a(href='/applications') Applications
@@ -147,11 +148,12 @@ html
                 tr
                     td(style='text-align:left; color: #999999;')!= glob.footer
                     td(style='text-align:right; color:#999999;')
-                        | Built by <a href='http://www.haufe-lexware.com' target='_blank'>Haufe-Lexware</a>, powered by <a href='http://getkong.org' target='_blank'>Mashape Kong</a>.
+                        if glob.layout.showBuiltByInFooter
+                            | Built by <a href='http://www.haufe-lexware.com' target='_blank'>Haufe-Lexware</a>, powered by <a href='http://getkong.org' target='_blank'>Mashape Kong</a>.
                 tr
                     if (authUser && authUser.admin)
                         td(colspan=2 style='text-align:right; color: #cccccc; font-size: 10pt;') Portal Build: #{glob.buildDate} -- <a href='/admin/health'>Config Build: #{glob.configDate}</a>
-                    else
+                    else if glob.layout.showBuiltByInFooter
                         td(colspan=2 style='text-align:right; color: #cccccc; font-size: 10pt;') Portal Build: #{glob.buildDate} -- Config Build: #{glob.configDate}
                 if !glob.isProduction
                     tr
@@ -160,5 +162,5 @@ html
     script(src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js')
     script(src='/js/bootstrap.min.js')
     script(src='/js/bootstrap-show-password.min.js')
- 
+
     block bodyScripts

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -58,55 +58,59 @@ html
                     span.icon-bar
                     span.icon-bar
                     span.icon-bar
-                a.pull-left(href='/')
-                    img(src='/content/images/wicked-40.png' style='margin-top: 5px; margin-right: 5px;' title='wicked project home')
+                a.pull-left(href=glob.layouts.defautRootUrl target=glob.layouts.defautRootUrlTarget)
+                    if glob.layouts.defautRootUrlText != null
+                        span= glob.layouts.defautRootUrlText
+                    else
+                        img(src='/content/images/wicked-40.png' style='margin-top: 5px; margin-right: 5px;' title='wicked project home')
 
             div(id="navbar", class="collapse navbar-collapse")
                 ul(class="nav navbar-nav")
                     if (route == '/')
                         li.active
-                            a(href="/") Home
+                            a(href="/")= glob.layouts.menu.homeLinkText
                     else
                         li
-                            a(href="/") Home
+                            a(href="/")= glob.layouts.menu.homeLinkText
                     if route == '/apis'
                         li.active
                             a(href="/apis") APIs
-                    else if glob.layout.linkMenuVisibleToGuest || authUser
+                    else if glob.layouts.menu.apisLinkVisibleToGuest || authUser
                         li
                             a(href="/apis") APIs
-
                     if route == '/applications'
                         li.active
                             a(href='/applications') Applications
-                    else
+                    else if glob.layouts.menu.applicationsLinkVisibleToGuest || authUser
                         li
                             a(href='/applications') Applications
                     if route == '/content/contact'
                         li.active
                             a(href="/content/contact") Contact
-                    else
+                    else if glob.layouts.menu.contactLinkVisibleToGuest || authUser
                         li
                             a(href="/content/contact") Contact
                     if route == '/content/toc'
                         li.active
                             a(href="/content/toc") Content
-                    else
+                    else if glob.layouts.menu.contentLinkVisibleToGuest || authUser
                         li
                             a(href="/content/toc") Content
+                ul(class='nav navbar-nav navbar-#{glob.layouts.menu.classForLoginSignupPosition}')
                     if !authUser
-                        if route == '/signup'
-                            li.active
-                                a(href="/signup") Sign up
-                        else
-                            li
-                                a(href="/signup") Sign up
+                        if glob.layouts.menu.showSignupLink
+                            if route == '/signup'
+                                li.active
+                                    a(href="/signup") Sign up
+                            else
+                                li
+                                    a(href="/signup") Sign up
                         if route == '/login'
                             li.active
-                                a(href="/login") Log in
+                                a(href="/login")= glob.layouts.menu.loginLinkText
                         else
                             li
-                                a(href="/login") Log in
+                                a(href="/login")= glob.layouts.menu.loginLinkText
                 if authUser
                     ul(class='nav navbar-nav navbar-right')
                         li
@@ -148,12 +152,12 @@ html
                 tr
                     td(style='text-align:left; color: #999999;')!= glob.footer
                     td(style='text-align:right; color:#999999;')
-                        if glob.layout.showBuiltByInFooter
+                        if glob.layouts.footer.showBuiltBy
                             | Built by <a href='http://www.haufe-lexware.com' target='_blank'>Haufe-Lexware</a>, powered by <a href='http://getkong.org' target='_blank'>Mashape Kong</a>.
                 tr
                     if (authUser && authUser.admin)
                         td(colspan=2 style='text-align:right; color: #cccccc; font-size: 10pt;') Portal Build: #{glob.buildDate} -- <a href='/admin/health'>Config Build: #{glob.configDate}</a>
-                    else if glob.layout.showBuiltByInFooter
+                    else if glob.layouts.footer.showBuilds
                         td(colspan=2 style='text-align:right; color: #cccccc; font-size: 10pt;') Portal Build: #{glob.buildDate} -- Config Build: #{glob.configDate}
                 if !glob.isProduction
                     tr

--- a/views/swagger-ui.jade
+++ b/views/swagger-ui.jade
@@ -46,7 +46,7 @@ html
           client_secret = decodeURIComponent(client_secret[1]);
         else
           client_secret = null;
-          
+
         var supportedMethods = [];
         if (apikey || client_id)
           supportedMethods = ['get', 'post', 'put', 'delete', 'patch'];
@@ -65,7 +65,7 @@ html
                 clientId: "your-client-id",
                 clientSecret: "your-client-secret-if-required",
                 realm: "your-realms",
-                appName: "your-app-name", 
+                appName: "your-app-name",
                 scopeSeparator: ",",
                 additionalQueryStringParams: {}
               });
@@ -115,10 +115,13 @@ body.swagger-section
 
   div(id='header')
     div(style="color:#cccccc;").swagger-ui-wrap
-      a(id="logo" href="#{glob.network.schema}://#{glob.network.portalHost}/") Home
+      a(id="logo" href="#{glob.network.schema}://#{glob.network.portalHost}/")= glob.layouts.swaggerUi.menu.homeLinkText
       a(href="#{glob.network.schema}://#{glob.network.portalHost}/apis").header-item APIs
       a(href="#{glob.network.schema}://#{glob.network.portalHost}/applications").header-item Applications
-      a(href="#{glob.network.schema}://#{glob.network.portalHost}/content/contact").header-item Contact
+      if glob.layouts.swaggerUi.menu.showContactLink
+        a(href="#{glob.network.schema}://#{glob.network.portalHost}/content/contact").header-item Contact
+      if glob.layouts.swaggerUi.menu.showContentLink
+        a(href="#{glob.network.schema}://#{glob.network.portalHost}/content/toc").header-item Content
 
   div(id="message-bar" class="swagger-ui-wrap" data-sw-translate) &nbsp;
   div(id="swagger-ui-container" class="swagger-ui-wrap")


### PR DESCRIPTION
Hi,

This first PR add 3 options in the `layout` namespace to allow a light customization of the main layout.
It should be safe as it keep the same behaviour as before for the layout.

  wicked.portal
    - Link correction in the layout menu (Hard coded link to main Wicked website)
    - Add option to hide API and Applications to guest (not connected users)
    - Add option to hide software details in the footer
  
  wicked.portal-env
    - Add options in the default `globals.json` config file

Issue: Haufe-Lexware/wicked.haufe.io/issues/66

